### PR TITLE
Consistently use git:// URLs for submodules (never git@: URLs)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	url = git://github.com/timrwood/moment.git
 [submodule "vendor/assets/javascripts/wysihtml5"]
 	path = vendor/assets/javascripts/wysihtml5
-	url = git@github.com:xing/wysihtml5.git
+	url = git://github.com/xing/wysihtml5.git
 [submodule "vendor/assets/javascripts/bootstrap-wysihtml5"]
 	path = vendor/assets/javascripts/bootstrap-wysihtml5
-	url = git@github.com:jhollingworth/bootstrap-wysihtml5.git
+	url = git://github.com/jhollingworth/bootstrap-wysihtml5.git


### PR DESCRIPTION
A couple submodules used ssh URLs so cloning them without GitHub ssh keys didn't work. I changed them to use git:// URLs like the rest so that cloning is now a little easier.

-- Lassi/HYTKY